### PR TITLE
Develop 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj
+/*.xcodeproj/project.xcworkspace/xcuserdata
+/*.xcodeproj/xcuserdata
+/Carthage
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ let angle      = a.angle(from: b)      // 1.5708
 
 let c: Vector3 = [1.0, 2.0, -2.0]
 let unit       = c.unit                // [0.333333, 0.666667, -0.666667]
+
+// interoperability with CoreGraphics
+let v = Vector2(cgPoint: CGPoint(x: 2, y: 3))
+let p = v.cgPoint
 ```
 
 ## Installation

--- a/Sources/Swiftor/CoreGraphics.swift
+++ b/Sources/Swiftor/CoreGraphics.swift
@@ -1,0 +1,23 @@
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import CoreGraphics
+
+extension Vector2 { // CGPoint
+    public init(cgPoint: CGPoint) {
+        self.init(x: Double(cgPoint.x), y: Double(cgPoint.y))
+    }
+    
+    public var cgPoint: CGPoint {
+        return CGPoint(x: CGFloat(x), y: CGFloat(y))
+    }
+}
+
+extension Vector2 { // CGSize
+    public init(cgSize: CGSize) {
+        self.init(x: Double(cgSize.width), y: Double(cgSize.height))
+    }
+    
+    public var cgSize: CGSize {
+        return CGSize(width: CGFloat(x), height: CGFloat(y))
+    }
+}
+#endif

--- a/Sources/Swiftor/Info.plist
+++ b/Sources/Swiftor/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/Swiftor/Swiftor.h
+++ b/Sources/Swiftor/Swiftor.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for Swiftor.
+FOUNDATION_EXPORT double SwiftorVersionNumber;
+
+//! Project version string for Swiftor.
+FOUNDATION_EXPORT const unsigned char SwiftorVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Swiftor/PublicHeader.h>
+
+

--- a/Sources/Swiftor/Vector.swift
+++ b/Sources/Swiftor/Vector.swift
@@ -3,43 +3,43 @@ import Foundation
 public protocol Vector: Equatable, CustomStringConvertible, CustomDebugStringConvertible {
     static func +(lhs: Self, rhs: Self) -> Self
     static func -(lhs: Self, rhs: Self) -> Self
-    static func *(lhs: Self, rhs: Float) -> Self
-    static func *(lhs: Float, rhs: Self) -> Self
-    static func /(lhs: Self, rhs: Float) -> Self
+    static func *(lhs: Self, rhs: Double) -> Self
+    static func *(lhs: Double, rhs: Self) -> Self
+    static func /(lhs: Self, rhs: Double) -> Self
     
-    var squareLength: Float { get }
-    var length: Float { get }
-    func squareDistance(from: Self) -> Float
-    func distance(from: Self) -> Float
+    var squareLength: Double { get }
+    var length: Double { get }
+    func squareDistance(from: Self) -> Double
+    func distance(from: Self) -> Double
     
     var unit: Self { get }
     
-    func dotProduct(with: Self) -> Float
+    func dotProduct(with: Self) -> Double
 
-    func cos(from: Self) -> Float
-    func angle(from: Self) -> Float
+    func cos(from: Self) -> Double
+    func angle(from: Self) -> Double
     
     static var zero: Self { get }
 }
 
 extension Vector {
-    public static func *(lhs: Float, rhs: Self) -> Self {
+    public static func *(lhs: Double, rhs: Self) -> Self {
         return rhs * lhs
     }
     
-    public var squareLength: Float {
+    public var squareLength: Double {
         return dotProduct(with: self)
     }
     
-    public var length: Float {
+    public var length: Double {
         return sqrt(squareLength)
     }
     
-    public func squareDistance(from vector: Self) -> Float {
+    public func squareDistance(from vector: Self) -> Double {
         return (self - vector).squareLength
     }
     
-    public func distance(from vector: Self) -> Float {
+    public func distance(from vector: Self) -> Double {
         return sqrt(squareDistance(from: vector))
     }
     
@@ -47,11 +47,11 @@ extension Vector {
         return self / length
     }
     
-    public func cos(from v: Self) -> Float {
+    public func cos(from v: Self) -> Double {
         return dotProduct(with: v) / sqrt(squareLength * v.squareLength)
     }
     
-    public func angle(from v: Self) -> Float {
+    public func angle(from v: Self) -> Double {
         let cosValue = cos(from: v)
         if cosValue < -1.0 {
             return .pi

--- a/Sources/Swiftor/Vector2.swift
+++ b/Sources/Swiftor/Vector2.swift
@@ -1,13 +1,13 @@
 public struct Vector2: Vector, Codable {
-    public var x: Float
-    public var y: Float
+    public var x: Double
+    public var y: Double
     
-    public init(x: Float, y: Float) {
+    public init(x: Double, y: Double) {
         self.x = x
         self.y = y
     }
     
-    public func dotProduct(with v: Vector2) -> Float {
+    public func dotProduct(with v: Vector2) -> Double {
         return x * v.x + y * v.y
     }
     
@@ -30,11 +30,11 @@ public func -(lhs: Vector2, rhs: Vector2) -> Vector2 {
     return Vector2(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
 }
 
-public func *(lhs: Vector2, rhs: Float) -> Vector2 {
+public func *(lhs: Vector2, rhs: Double) -> Vector2 {
     return Vector2(x: lhs.x * rhs, y: lhs.y * rhs)
 }
 
-public func /(lhs: Vector2, rhs: Float) -> Vector2 {
+public func /(lhs: Vector2, rhs: Double) -> Vector2 {
     return Vector2(x: lhs.x / rhs, y: lhs.y / rhs)
 }
 
@@ -43,7 +43,7 @@ public func ==(lhs: Vector2, rhs: Vector2) -> Bool {
 }
 
 extension Vector2: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Float...) {
+    public init(arrayLiteral elements: Double...) {
         precondition(elements.count == 2)
         
         self.init(x: elements[0], y: elements[1])

--- a/Sources/Swiftor/Vector3.swift
+++ b/Sources/Swiftor/Vector3.swift
@@ -1,15 +1,15 @@
 public struct Vector3: Vector, Codable {
-    public var x: Float
-    public var y: Float
-    public var z: Float
+    public var x: Double
+    public var y: Double
+    public var z: Double
     
-    public init(x: Float, y: Float, z: Float) {
+    public init(x: Double, y: Double, z: Double) {
         self.x = x
         self.y = y
         self.z = z
     }
     
-    public func dotProduct(with v: Vector3) -> Float {
+    public func dotProduct(with v: Vector3) -> Double {
         return x * v.x + y * v.y + z * v.z
     }
     
@@ -32,11 +32,11 @@ public func -(lhs: Vector3, rhs: Vector3) -> Vector3 {
     return Vector3(x: lhs.x - rhs.x, y: lhs.y - rhs.y, z: lhs.z - rhs.z)
 }
 
-public func *(lhs: Vector3, rhs: Float) -> Vector3 {
+public func *(lhs: Vector3, rhs: Double) -> Vector3 {
     return Vector3(x: lhs.x * rhs, y: lhs.y * rhs, z: lhs.z * rhs)
 }
 
-public func /(lhs: Vector3, rhs: Float) -> Vector3 {
+public func /(lhs: Vector3, rhs: Double) -> Vector3 {
     return Vector3(x: lhs.x / rhs, y: lhs.y / rhs, z: lhs.z / rhs)
 }
 
@@ -45,7 +45,7 @@ public func ==(lhs: Vector3, rhs: Vector3) -> Bool {
 }
 
 extension Vector3: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Float...) {
+    public init(arrayLiteral elements: Double...) {
         precondition(elements.count == 3)
         
         self.init(x: elements[0], y: elements[1], z: elements[2])

--- a/Sources/Swiftor/Vector4.swift
+++ b/Sources/Swiftor/Vector4.swift
@@ -1,0 +1,55 @@
+public struct Vector4: Vector, Codable {
+    public var x: Double
+    public var y: Double
+    public var z: Double
+    public var w: Double
+    
+    public init(x: Double, y: Double, z: Double, w: Double) {
+        self.x = x
+        self.y = y
+        self.z = z
+        self.w = w
+    }
+    
+    public func dotProduct(with v: Vector4) -> Double {
+        return x * v.x + y * v.y + z * v.z + w * v.w
+    }
+    
+    public static let zero: Vector4 = Vector4(x: 0, y: 0, z: 0, w: 0)
+    
+    public var description: String {
+        return "[\(x.description), \(y.description), \(z.description), \(w.description)]"
+    }
+    
+    public var debugDescription: String {
+        return "[\(x.debugDescription), \(y.debugDescription), \(z.debugDescription), \(w.debugDescription)]"
+    }
+}
+
+public func +(lhs: Vector4, rhs: Vector4) -> Vector4 {
+    return Vector4(x: lhs.x + rhs.x, y: lhs.y + rhs.y, z: lhs.z + rhs.z, w: lhs.w + rhs.w)
+}
+
+public func -(lhs: Vector4, rhs: Vector4) -> Vector4 {
+    return Vector4(x: lhs.x - rhs.x, y: lhs.y - rhs.y, z: lhs.z - rhs.z, w: lhs.w - rhs.w)
+}
+
+public func *(lhs: Vector4, rhs: Double) -> Vector4 {
+    return Vector4(x: lhs.x * rhs, y: lhs.y * rhs, z: lhs.z * rhs, w: lhs.w * rhs)
+}
+
+public func /(lhs: Vector4, rhs: Double) -> Vector4 {
+    return Vector4(x: lhs.x / rhs, y: lhs.y / rhs, z: lhs.z / rhs, w: lhs.w / rhs)
+}
+
+public func ==(lhs: Vector4, rhs: Vector4) -> Bool {
+    return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z
+}
+
+extension Vector4: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Double...) {
+        precondition(elements.count == 4)
+        
+        self.init(x: elements[0], y: elements[1], z: elements[2], w: elements[3])
+    }
+}

--- a/Swiftor.xcodeproj/project.pbxproj
+++ b/Swiftor.xcodeproj/project.pbxproj
@@ -1,0 +1,1022 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D66A1D8A205674300021C59A /* Swiftor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D66A1D80205674300021C59A /* Swiftor.framework */; };
+		D66A1DA3205675C70021C59A /* Swiftor.h in Headers */ = {isa = PBXBuildFile; fileRef = D66A1D9D205675C70021C59A /* Swiftor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D66A1DA4205675C70021C59A /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9E205675C70021C59A /* Vector.swift */; };
+		D66A1DA5205675C70021C59A /* Vector2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9F205675C70021C59A /* Vector2.swift */; };
+		D66A1DA6205675C70021C59A /* Vector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA0205675C70021C59A /* Vector3.swift */; };
+		D66A1DA7205675C70021C59A /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA1205675C70021C59A /* Vector4.swift */; };
+		D66A1DAF205675D10021C59A /* SwiftorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DAC205675D10021C59A /* SwiftorTests.swift */; };
+		D66A1DBE205676D60021C59A /* Swiftor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D66A1DB5205676D60021C59A /* Swiftor.framework */; };
+		D66A1DDA2056770A0021C59A /* Swiftor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D66A1DD12056770A0021C59A /* Swiftor.framework */; };
+		D66A1DF52056795F0021C59A /* Swiftor.h in Headers */ = {isa = PBXBuildFile; fileRef = D66A1D9D205675C70021C59A /* Swiftor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D66A1DF62056795F0021C59A /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9E205675C70021C59A /* Vector.swift */; };
+		D66A1DF72056795F0021C59A /* Vector2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9F205675C70021C59A /* Vector2.swift */; };
+		D66A1DF82056795F0021C59A /* Vector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA0205675C70021C59A /* Vector3.swift */; };
+		D66A1DF92056795F0021C59A /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA1205675C70021C59A /* Vector4.swift */; };
+		D66A1DFA205679600021C59A /* Swiftor.h in Headers */ = {isa = PBXBuildFile; fileRef = D66A1D9D205675C70021C59A /* Swiftor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D66A1DFB205679600021C59A /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9E205675C70021C59A /* Vector.swift */; };
+		D66A1DFC205679600021C59A /* Vector2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9F205675C70021C59A /* Vector2.swift */; };
+		D66A1DFD205679600021C59A /* Vector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA0205675C70021C59A /* Vector3.swift */; };
+		D66A1DFE205679600021C59A /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA1205675C70021C59A /* Vector4.swift */; };
+		D66A1DFF205679600021C59A /* Swiftor.h in Headers */ = {isa = PBXBuildFile; fileRef = D66A1D9D205675C70021C59A /* Swiftor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D66A1E00205679600021C59A /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9E205675C70021C59A /* Vector.swift */; };
+		D66A1E01205679600021C59A /* Vector2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1D9F205675C70021C59A /* Vector2.swift */; };
+		D66A1E02205679600021C59A /* Vector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA0205675C70021C59A /* Vector3.swift */; };
+		D66A1E03205679600021C59A /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA1205675C70021C59A /* Vector4.swift */; };
+		D66A1E04205679770021C59A /* SwiftorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DAC205675D10021C59A /* SwiftorTests.swift */; };
+		D66A1E05205679770021C59A /* SwiftorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DAC205675D10021C59A /* SwiftorTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D66A1D8B205674300021C59A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D66A1D77205674300021C59A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D66A1D7F205674300021C59A;
+			remoteInfo = Swiftor;
+		};
+		D66A1DBF205676D60021C59A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D66A1D77205674300021C59A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D66A1DB4205676D60021C59A;
+			remoteInfo = "Swiftor-macOS";
+		};
+		D66A1DDB2056770A0021C59A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D66A1D77205674300021C59A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D66A1DD02056770A0021C59A;
+			remoteInfo = "Swiftor-tvOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D66A1D80205674300021C59A /* Swiftor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1D89205674300021C59A /* SwiftorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1D9C205675C70021C59A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D66A1D9D205675C70021C59A /* Swiftor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Swiftor.h; sourceTree = "<group>"; };
+		D66A1D9E205675C70021C59A /* Vector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector.swift; sourceTree = "<group>"; };
+		D66A1D9F205675C70021C59A /* Vector2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector2.swift; sourceTree = "<group>"; };
+		D66A1DA0205675C70021C59A /* Vector3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector3.swift; sourceTree = "<group>"; };
+		D66A1DA1205675C70021C59A /* Vector4.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector4.swift; sourceTree = "<group>"; };
+		D66A1DA9205675D10021C59A /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
+		D66A1DAB205675D10021C59A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D66A1DAC205675D10021C59A /* SwiftorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftorTests.swift; sourceTree = "<group>"; };
+		D66A1DB5205676D60021C59A /* Swiftor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1DBD205676D60021C59A /* SwiftorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1DD12056770A0021C59A /* Swiftor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1DD92056770A0021C59A /* SwiftorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1DED2056771A0021C59A /* Swiftor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D66A1D7C205674300021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1D86205674300021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1D8A205674300021C59A /* Swiftor.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DB1205676D60021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DBA205676D60021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DBE205676D60021C59A /* Swiftor.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DCD2056770A0021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DD62056770A0021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DDA2056770A0021C59A /* Swiftor.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DE92056771A0021C59A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D66A1D76205674300021C59A = {
+			isa = PBXGroup;
+			children = (
+				D66A1D9A205675C70021C59A /* Sources */,
+				D66A1DA8205675D10021C59A /* Tests */,
+				D66A1D81205674300021C59A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D66A1D81205674300021C59A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D66A1D80205674300021C59A /* Swiftor.framework */,
+				D66A1D89205674300021C59A /* SwiftorTests.xctest */,
+				D66A1DB5205676D60021C59A /* Swiftor.framework */,
+				D66A1DBD205676D60021C59A /* SwiftorTests.xctest */,
+				D66A1DD12056770A0021C59A /* Swiftor.framework */,
+				D66A1DD92056770A0021C59A /* SwiftorTests.xctest */,
+				D66A1DED2056771A0021C59A /* Swiftor.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D66A1D9A205675C70021C59A /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				D66A1D9B205675C70021C59A /* Swiftor */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		D66A1D9B205675C70021C59A /* Swiftor */ = {
+			isa = PBXGroup;
+			children = (
+				D66A1D9C205675C70021C59A /* Info.plist */,
+				D66A1D9D205675C70021C59A /* Swiftor.h */,
+				D66A1D9E205675C70021C59A /* Vector.swift */,
+				D66A1D9F205675C70021C59A /* Vector2.swift */,
+				D66A1DA0205675C70021C59A /* Vector3.swift */,
+				D66A1DA1205675C70021C59A /* Vector4.swift */,
+			);
+			path = Swiftor;
+			sourceTree = "<group>";
+		};
+		D66A1DA8205675D10021C59A /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				D66A1DA9205675D10021C59A /* LinuxMain.swift */,
+				D66A1DAA205675D10021C59A /* SwiftorTests */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		D66A1DAA205675D10021C59A /* SwiftorTests */ = {
+			isa = PBXGroup;
+			children = (
+				D66A1DAB205675D10021C59A /* Info.plist */,
+				D66A1DAC205675D10021C59A /* SwiftorTests.swift */,
+			);
+			path = SwiftorTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D66A1D7D205674300021C59A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DA3205675C70021C59A /* Swiftor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DB2205676D60021C59A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DF52056795F0021C59A /* Swiftor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DCE2056770A0021C59A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DFA205679600021C59A /* Swiftor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DEA2056771A0021C59A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DFF205679600021C59A /* Swiftor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		D66A1D7F205674300021C59A /* Swiftor-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1D94205674300021C59A /* Build configuration list for PBXNativeTarget "Swiftor-iOS" */;
+			buildPhases = (
+				D66A1D7B205674300021C59A /* Sources */,
+				D66A1D7C205674300021C59A /* Frameworks */,
+				D66A1D7D205674300021C59A /* Headers */,
+				D66A1D7E205674300021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Swiftor-iOS";
+			productName = Swiftor;
+			productReference = D66A1D80205674300021C59A /* Swiftor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D66A1D88205674300021C59A /* SwiftorTests-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1D97205674300021C59A /* Build configuration list for PBXNativeTarget "SwiftorTests-iOS" */;
+			buildPhases = (
+				D66A1D85205674300021C59A /* Sources */,
+				D66A1D86205674300021C59A /* Frameworks */,
+				D66A1D87205674300021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D66A1D8C205674300021C59A /* PBXTargetDependency */,
+			);
+			name = "SwiftorTests-iOS";
+			productName = SwiftorTests;
+			productReference = D66A1D89205674300021C59A /* SwiftorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D66A1DB4205676D60021C59A /* Swiftor-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1DC6205676D60021C59A /* Build configuration list for PBXNativeTarget "Swiftor-macOS" */;
+			buildPhases = (
+				D66A1DB0205676D60021C59A /* Sources */,
+				D66A1DB1205676D60021C59A /* Frameworks */,
+				D66A1DB2205676D60021C59A /* Headers */,
+				D66A1DB3205676D60021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Swiftor-macOS";
+			productName = "Swiftor-macOS";
+			productReference = D66A1DB5205676D60021C59A /* Swiftor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D66A1DBC205676D60021C59A /* Swiftor-macOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1DC9205676D60021C59A /* Build configuration list for PBXNativeTarget "Swiftor-macOSTests" */;
+			buildPhases = (
+				D66A1DB9205676D60021C59A /* Sources */,
+				D66A1DBA205676D60021C59A /* Frameworks */,
+				D66A1DBB205676D60021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D66A1DC0205676D60021C59A /* PBXTargetDependency */,
+			);
+			name = "Swiftor-macOSTests";
+			productName = "Swiftor-macOSTests";
+			productReference = D66A1DBD205676D60021C59A /* SwiftorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D66A1DD02056770A0021C59A /* Swiftor-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1DE22056770A0021C59A /* Build configuration list for PBXNativeTarget "Swiftor-tvOS" */;
+			buildPhases = (
+				D66A1DCC2056770A0021C59A /* Sources */,
+				D66A1DCD2056770A0021C59A /* Frameworks */,
+				D66A1DCE2056770A0021C59A /* Headers */,
+				D66A1DCF2056770A0021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Swiftor-tvOS";
+			productName = "Swiftor-tvOS";
+			productReference = D66A1DD12056770A0021C59A /* Swiftor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D66A1DD82056770A0021C59A /* Swiftor-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1DE52056770A0021C59A /* Build configuration list for PBXNativeTarget "Swiftor-tvOSTests" */;
+			buildPhases = (
+				D66A1DD52056770A0021C59A /* Sources */,
+				D66A1DD62056770A0021C59A /* Frameworks */,
+				D66A1DD72056770A0021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D66A1DDC2056770A0021C59A /* PBXTargetDependency */,
+			);
+			name = "Swiftor-tvOSTests";
+			productName = "Swiftor-tvOSTests";
+			productReference = D66A1DD92056770A0021C59A /* SwiftorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D66A1DEC2056771A0021C59A /* Swiftor-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D66A1DF22056771A0021C59A /* Build configuration list for PBXNativeTarget "Swiftor-watchOS" */;
+			buildPhases = (
+				D66A1DE82056771A0021C59A /* Sources */,
+				D66A1DE92056771A0021C59A /* Frameworks */,
+				D66A1DEA2056771A0021C59A /* Headers */,
+				D66A1DEB2056771A0021C59A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Swiftor-watchOS";
+			productName = "Swiftor-watchOS";
+			productReference = D66A1DED2056771A0021C59A /* Swiftor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D66A1D77205674300021C59A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = koherent.org;
+				TargetAttributes = {
+					D66A1D7F205674300021C59A = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					D66A1D88205674300021C59A = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					D66A1DB4205676D60021C59A = {
+						CreatedOnToolsVersion = 9.2;
+					};
+					D66A1DBC205676D60021C59A = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					D66A1DD02056770A0021C59A = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					D66A1DD82056770A0021C59A = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					D66A1DEC2056771A0021C59A = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = D66A1D7A205674300021C59A /* Build configuration list for PBXProject "Swiftor" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = D66A1D76205674300021C59A;
+			productRefGroup = D66A1D81205674300021C59A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D66A1D7F205674300021C59A /* Swiftor-iOS */,
+				D66A1D88205674300021C59A /* SwiftorTests-iOS */,
+				D66A1DB4205676D60021C59A /* Swiftor-macOS */,
+				D66A1DBC205676D60021C59A /* Swiftor-macOSTests */,
+				D66A1DD02056770A0021C59A /* Swiftor-tvOS */,
+				D66A1DD82056770A0021C59A /* Swiftor-tvOSTests */,
+				D66A1DEC2056771A0021C59A /* Swiftor-watchOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D66A1D7E205674300021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1D87205674300021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DB3205676D60021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DBB205676D60021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DCF2056770A0021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DD72056770A0021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DEB2056771A0021C59A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D66A1D7B205674300021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DA4205675C70021C59A /* Vector.swift in Sources */,
+				D66A1DA6205675C70021C59A /* Vector3.swift in Sources */,
+				D66A1DA5205675C70021C59A /* Vector2.swift in Sources */,
+				D66A1DA7205675C70021C59A /* Vector4.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1D85205674300021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DAF205675D10021C59A /* SwiftorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DB0205676D60021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DF62056795F0021C59A /* Vector.swift in Sources */,
+				D66A1DF82056795F0021C59A /* Vector3.swift in Sources */,
+				D66A1DF72056795F0021C59A /* Vector2.swift in Sources */,
+				D66A1DF92056795F0021C59A /* Vector4.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DB9205676D60021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1E04205679770021C59A /* SwiftorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DCC2056770A0021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1DFB205679600021C59A /* Vector.swift in Sources */,
+				D66A1DFD205679600021C59A /* Vector3.swift in Sources */,
+				D66A1DFC205679600021C59A /* Vector2.swift in Sources */,
+				D66A1DFE205679600021C59A /* Vector4.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DD52056770A0021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1E05205679770021C59A /* SwiftorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66A1DE82056771A0021C59A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D66A1E00205679600021C59A /* Vector.swift in Sources */,
+				D66A1E02205679600021C59A /* Vector3.swift in Sources */,
+				D66A1E01205679600021C59A /* Vector2.swift in Sources */,
+				D66A1E03205679600021C59A /* Vector4.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D66A1D8C205674300021C59A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D66A1D7F205674300021C59A /* Swiftor-iOS */;
+			targetProxy = D66A1D8B205674300021C59A /* PBXContainerItemProxy */;
+		};
+		D66A1DC0205676D60021C59A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D66A1DB4205676D60021C59A /* Swiftor-macOS */;
+			targetProxy = D66A1DBF205676D60021C59A /* PBXContainerItemProxy */;
+		};
+		D66A1DDC2056770A0021C59A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D66A1DD02056770A0021C59A /* Swiftor-tvOS */;
+			targetProxy = D66A1DDB2056770A0021C59A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		D66A1D92205674300021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D66A1D93205674300021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D66A1D95205674300021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D66A1D96205674300021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D66A1D98205674300021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/SwiftorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.SwiftorTests;
+				PRODUCT_NAME = SwiftorTests;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D66A1D99205674300021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/SwiftorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.SwiftorTests;
+				PRODUCT_NAME = SwiftorTests;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D66A1DC7205676D60021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		D66A1DC8205676D60021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		D66A1DCA205676D60021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/SwiftorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.SwiftorTests;
+				PRODUCT_NAME = SwiftorTests;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		D66A1DCB205676D60021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/SwiftorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.SwiftorTests;
+				PRODUCT_NAME = SwiftorTests;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		D66A1DE32056770A0021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 11.2;
+			};
+			name = Debug;
+		};
+		D66A1DE42056770A0021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 11.2;
+			};
+			name = Release;
+		};
+		D66A1DE62056770A0021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/SwiftorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.SwiftorTests;
+				PRODUCT_NAME = SwiftorTests;
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 11.2;
+			};
+			name = Debug;
+		};
+		D66A1DE72056770A0021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/SwiftorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.SwiftorTests;
+				PRODUCT_NAME = SwiftorTests;
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 11.2;
+			};
+			name = Release;
+		};
+		D66A1DF32056771A0021C59A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+			};
+			name = Debug;
+		};
+		D66A1DF42056771A0021C59A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/Swiftor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.Swiftor;
+				PRODUCT_NAME = Swiftor;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D66A1D7A205674300021C59A /* Build configuration list for PBXProject "Swiftor" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1D92205674300021C59A /* Debug */,
+				D66A1D93205674300021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1D94205674300021C59A /* Build configuration list for PBXNativeTarget "Swiftor-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1D95205674300021C59A /* Debug */,
+				D66A1D96205674300021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1D97205674300021C59A /* Build configuration list for PBXNativeTarget "SwiftorTests-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1D98205674300021C59A /* Debug */,
+				D66A1D99205674300021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1DC6205676D60021C59A /* Build configuration list for PBXNativeTarget "Swiftor-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1DC7205676D60021C59A /* Debug */,
+				D66A1DC8205676D60021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1DC9205676D60021C59A /* Build configuration list for PBXNativeTarget "Swiftor-macOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1DCA205676D60021C59A /* Debug */,
+				D66A1DCB205676D60021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1DE22056770A0021C59A /* Build configuration list for PBXNativeTarget "Swiftor-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1DE32056770A0021C59A /* Debug */,
+				D66A1DE42056770A0021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1DE52056770A0021C59A /* Build configuration list for PBXNativeTarget "Swiftor-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1DE62056770A0021C59A /* Debug */,
+				D66A1DE72056770A0021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D66A1DF22056771A0021C59A /* Build configuration list for PBXNativeTarget "Swiftor-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D66A1DF32056771A0021C59A /* Debug */,
+				D66A1DF42056771A0021C59A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D66A1D77205674300021C59A /* Project object */;
+}

--- a/Swiftor.xcodeproj/project.pbxproj
+++ b/Swiftor.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		D66A1E03205679600021C59A /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DA1205675C70021C59A /* Vector4.swift */; };
 		D66A1E04205679770021C59A /* SwiftorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DAC205675D10021C59A /* SwiftorTests.swift */; };
 		D66A1E05205679770021C59A /* SwiftorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1DAC205675D10021C59A /* SwiftorTests.swift */; };
+		D66A1E0720567D8C0021C59A /* CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1E0620567D8C0021C59A /* CoreGraphics.swift */; };
+		D66A1E0820567D8C0021C59A /* CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1E0620567D8C0021C59A /* CoreGraphics.swift */; };
+		D66A1E0920567D8C0021C59A /* CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1E0620567D8C0021C59A /* CoreGraphics.swift */; };
+		D66A1E0A20567D8C0021C59A /* CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66A1E0620567D8C0021C59A /* CoreGraphics.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +80,7 @@
 		D66A1DD12056770A0021C59A /* Swiftor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D66A1DD92056770A0021C59A /* SwiftorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D66A1DED2056771A0021C59A /* Swiftor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D66A1E0620567D8C0021C59A /* CoreGraphics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreGraphics.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +179,7 @@
 				D66A1D9F205675C70021C59A /* Vector2.swift */,
 				D66A1DA0205675C70021C59A /* Vector3.swift */,
 				D66A1DA1205675C70021C59A /* Vector4.swift */,
+				D66A1E0620567D8C0021C59A /* CoreGraphics.swift */,
 			);
 			path = Swiftor;
 			sourceTree = "<group>";
@@ -479,6 +485,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D66A1E0720567D8C0021C59A /* CoreGraphics.swift in Sources */,
 				D66A1DA4205675C70021C59A /* Vector.swift in Sources */,
 				D66A1DA6205675C70021C59A /* Vector3.swift in Sources */,
 				D66A1DA5205675C70021C59A /* Vector2.swift in Sources */,
@@ -498,6 +505,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D66A1E0820567D8C0021C59A /* CoreGraphics.swift in Sources */,
 				D66A1DF62056795F0021C59A /* Vector.swift in Sources */,
 				D66A1DF82056795F0021C59A /* Vector3.swift in Sources */,
 				D66A1DF72056795F0021C59A /* Vector2.swift in Sources */,
@@ -517,6 +525,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D66A1E0920567D8C0021C59A /* CoreGraphics.swift in Sources */,
 				D66A1DFB205679600021C59A /* Vector.swift in Sources */,
 				D66A1DFD205679600021C59A /* Vector3.swift in Sources */,
 				D66A1DFC205679600021C59A /* Vector2.swift in Sources */,
@@ -536,6 +545,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D66A1E0A20567D8C0021C59A /* CoreGraphics.swift in Sources */,
 				D66A1E00205679600021C59A /* Vector.swift in Sources */,
 				D66A1E02205679600021C59A /* Vector3.swift in Sources */,
 				D66A1E01205679600021C59A /* Vector2.swift in Sources */,

--- a/Swiftor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Swiftor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Swiftor.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-iOS.xcscheme
+++ b/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-iOS.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1D7F205674300021C59A"
+               BuildableName = "Swiftor.framework"
+               BlueprintName = "Swiftor-iOS"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1D88205674300021C59A"
+               BuildableName = "SwiftorTests.xctest"
+               BlueprintName = "SwiftorTests-iOS"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1D7F205674300021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-iOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1D7F205674300021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-iOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1D7F205674300021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-iOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-macOS.xcscheme
+++ b/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-macOS.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1DB4205676D60021C59A"
+               BuildableName = "Swiftor.framework"
+               BlueprintName = "Swiftor-macOS"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1DBC205676D60021C59A"
+               BuildableName = "SwiftorTests.xctest"
+               BlueprintName = "Swiftor-macOSTests"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DB4205676D60021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-macOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DB4205676D60021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-macOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DB4205676D60021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-macOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-tvOS.xcscheme
+++ b/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-tvOS.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1DD02056770A0021C59A"
+               BuildableName = "Swiftor.framework"
+               BlueprintName = "Swiftor-tvOS"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1DD82056770A0021C59A"
+               BuildableName = "SwiftorTests.xctest"
+               BlueprintName = "Swiftor-tvOSTests"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DD02056770A0021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-tvOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DD02056770A0021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-tvOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DD02056770A0021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-tvOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-watchOS.xcscheme
+++ b/Swiftor.xcodeproj/xcshareddata/xcschemes/Swiftor-watchOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D66A1DEC2056771A0021C59A"
+               BuildableName = "Swiftor.framework"
+               BlueprintName = "Swiftor-watchOS"
+               ReferencedContainer = "container:Swiftor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DEC2056771A0021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-watchOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D66A1DEC2056771A0021C59A"
+            BuildableName = "Swiftor.framework"
+            BlueprintName = "Swiftor-watchOS"
+            ReferencedContainer = "container:Swiftor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/SwiftorTests/Info.plist
+++ b/Tests/SwiftorTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Tests/SwiftorTests/SwiftorTests.swift
+++ b/Tests/SwiftorTests/SwiftorTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 @testable import Swiftor
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import CoreGraphics
+#endif
 
 class SwiftorTests: XCTestCase {
     func testExample() {
@@ -37,6 +40,18 @@ class SwiftorTests: XCTestCase {
         print(distance)
         print(angle)
         print(unit)
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        // interoperability with CoreGraphics
+        let v = Vector2(cgPoint: CGPoint(x: 2, y: 3))
+        let p = v.cgPoint
+        
+        XCTAssertEqual(v.x, 2.0)
+        XCTAssertEqual(v.y, 3.0)
+        XCTAssertEqual(p.x, 2.0)
+        XCTAssertEqual(p.y, 3.0)
+        #endif
+        
     }
 
     static var allTests : [(String, (SwiftorTests) -> () throws -> Void)] {


### PR DESCRIPTION
- Changes types of elements from `Float` to `Double`
- Supports Carthage
  - Makes it possible to use Swiftor for iOS, tvOS and watchOS
- `Vector4`
- Interoperability with CoreGraphics
  - Between `Vector2` and `CGPoint/CGSize`
